### PR TITLE
Fix: handler.lua:132: attempt to index field 'http_log_extended' (a nil value)

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -129,7 +129,11 @@ function HttpLogExtendedHandler:body_filter(conf)
     local ctx = ngx.ctx
     local res_body = ctx.http_log_extended and ctx.http_log_extended.res_body or ""
     res_body = res_body .. (chunk or "")
-    ctx.http_log_extended.res_body = res_body
+    if (ctx.http_log_extended) then 
+      ctx.http_log_extended.res_body = res_body
+    else
+      ctx.http_log_extended = { req_body = res_body }
+    end 
   end 
 end 
 

--- a/handler.lua
+++ b/handler.lua
@@ -132,7 +132,7 @@ function HttpLogExtendedHandler:body_filter(conf)
     if (ctx.http_log_extended) then 
       ctx.http_log_extended.res_body = res_body
     else
-      ctx.http_log_extended = { req_body = res_body }
+      ctx.http_log_extended = { res_body = res_body }
     end 
   end 
 end 


### PR DESCRIPTION
I test this plugin, I got this error:
 > handler.lua:132: attempt to index field 'http_log_extended' (a nil value)

I fixed by checking if ctx.http_log_extended is existed or not?
I have tested. It is worked.